### PR TITLE
Suggestion: More compact UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@electron-forge/publisher-github": "^7.6.0",
     "@electron/fuses": "^1.8.0",
     "electron": "^40.2.1",
-    "electron-builder": "^26.15.3"
+    "electron-builder": "^26.4.0"
   },
   "overrides": {
     "tar": "7.5.15",
@@ -67,9 +67,7 @@
       "artifactName": "${productName}-Setup-${version}.${ext}"
     },
     "linux": {
-      "target": [
-        "AppImage"
-      ],
+      "target": ["AppImage"],
       "artifactName": "${productName}-${version}.${ext}",
       "icon": "src/assets/icon.png"
     }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@electron-forge/publisher-github": "^7.6.0",
     "@electron/fuses": "^1.8.0",
     "electron": "^40.2.1",
-    "electron-builder": "^26.4.0"
+    "electron-builder": "^26.15.3"
   },
   "overrides": {
     "tar": "7.5.15",
@@ -67,7 +67,9 @@
       "artifactName": "${productName}-Setup-${version}.${ext}"
     },
     "linux": {
-      "target": ["AppImage"],
+      "target": [
+        "AppImage"
+      ],
       "artifactName": "${productName}-${version}.${ext}",
       "icon": "src/assets/icon.png"
     }

--- a/src/index.html
+++ b/src/index.html
@@ -2,250 +2,307 @@
 <html>
 <head>
   <link rel="stylesheet" type="text/css" href="main.css" />
-</head>
-<body>
-  <div id="tabs-bar" style="width: 100%; display: flex; align-items: stretch;">
-    <div id="tabs" style="overflow-x: auto; white-space: nowrap; flex: 1 1 auto; display: flex; align-items: stretch;">
-      <button id="nav-panel-toggle" style="display: flex; align-items: center; justify-content: center; font-size: 22px; border: none; background: #8b6914; color: #fff; border-radius: 8px 0 0 8px; width: 36px; height: 36px; cursor: pointer; margin-right: 4px; transition: background 0.2s;">&gt;</button>
-      <button id="nav-panel-strip-toggle" title="Toggle strip mode" style="display: flex; align-items: center; justify-content: center; font-size: 16px; border: none; background: #3d2807; color: #fff; border-radius: 6px; width: 36px; height: 36px; cursor: pointer; margin-right: 8px; transition: background 0.15s;">≡</button>
-      <div class="tab active" data-id="main">W2 HD</div>
-    </div>
-  </div>
-  <div id="chat-resizer">
-    <div id="chat-resizer-line"></div>
-  </div>
   <style>
-    #chat-resizer {
-      position: fixed;
-      left: 0;
-      right: 250px; /* matches NAV_PANEL_WIDTH */
-      height: 5px;
-      cursor: ns-resize;
-      z-index: 11;
-      display: none;
-      align-items: center;
-      transition: bottom 0.01s linear; /* JS drives this, keep near-instant */
+    .nav {
+      width: 190px;
+      height: 100%;
+      border: 0px;
+      padding: 0px;
+      overflow-y: clip;
     }
-    #chat-resizer-line {
-      width: 100%;
-      height: 2px;
-      background: linear-gradient(90deg, transparent 0%, #5a4510 10%, #8b6914 40%, #c8941c 50%, #8b6914 60%, #5a4510 90%, transparent 100%);
-      pointer-events: none;
-      transition: opacity 0.15s;
-      opacity: 0.7;
+
+    .nav-buttons-top {
+      display: flex;
+      gap: 4px;
+      margin-bottom: 8px;
+      padding-bottom: 8px;
     }
-    #chat-resizer:hover #chat-resizer-line,
-    #chat-resizer.dragging #chat-resizer-line {
-      opacity: 1;
-      background: linear-gradient(90deg, transparent 0%, #8b6914 10%, #f0e68c 40%, #c8941c 50%, #f0e68c 60%, #8b6914 90%, transparent 100%);
+    
+    .nav-buttons-top .nav-icon {
+      width: 18px;
+      height: 18px;
+      margin: 0px 5px;
+      align-self: center;
+    }
+
+    .nav-button {
+      height: 10%;
     }
   </style>
-  <script>
-    const { ipcRenderer } = require('electron');
-
-    let currentTab = 'main';
-    let navPanelCollapsed = false;
-
-    const navPanelToggleBtn = document.getElementById('nav-panel-toggle');
-    function setNavPanelToggleState(collapsed) {
-      navPanelToggleBtn.textContent = collapsed ? '<' : '>';
-      navPanelToggleBtn.style.alignItems = 'center';
-      navPanelToggleBtn.style.justifyContent = 'center';
-      navPanelToggleBtn.style.background = collapsed ? 'transparent' : '#8b6914';
-      navPanelToggleBtn.style.color = collapsed ? '#8b6914' : '#fff';
-      navPanelToggleBtn.style.border = collapsed ? '2px solid #8b6914' : 'none';
-
-      // Actually hide/show the nav panel
-      const navPanel = document.getElementById('nav-panel');
-      if (navPanel) {
-        if (collapsed) {
-          navPanel.style.display = 'none';
-        } else {
-          navPanel.style.display = '';
-        }
-      }
-    }
-    navPanelToggleBtn.onclick = () => {
-      navPanelCollapsed = !navPanelCollapsed;
-      setNavPanelToggleState(navPanelCollapsed);
-      require('electron').ipcRenderer.send('toggle-nav-panel');
-    };
-    const navPanelStripToggleBtn = document.getElementById('nav-panel-strip-toggle');
-    if (navPanelStripToggleBtn) {
-      navPanelStripToggleBtn.addEventListener('click', () => {
-        require('electron').ipcRenderer.send('toggle-nav-panel-mode');
-      });
-    }
-    require('electron').ipcRenderer.on('nav-panel-collapsed', (event, collapsed) => {
-      navPanelCollapsed = collapsed;
-      setNavPanelToggleState(collapsed);
-    });
-    require('electron').ipcRenderer.on('nav-panel-mode', (event, mode) => {
-      const btn = document.getElementById('nav-panel-strip-toggle');
-      if (!btn) return;
-      if (mode === 'strip') {
-        btn.style.background = '#51cf66';
-        btn.title = 'Strip mode enabled';
-      } else {
-        btn.style.background = '#3d2807';
-        btn.title = 'Enable strip mode';
-      }
-    });
-    // Set initial state (in case of reload)
-    setNavPanelToggleState(navPanelCollapsed);
-
-    document.getElementById('tabs').addEventListener('click', (e) => {
-      if (e.target.classList.contains('close')) {
-        e.stopPropagation();
-        const tab = e.target.parentElement;
-        ipcRenderer.send('close-tab', tab.dataset.id);
-      } else if (e.target.classList.contains('tab')) {
-        ipcRenderer.send('switch-tab', e.target.dataset.id);
-      }
-    });
-
-    ipcRenderer.on('add-tab', (event, id, title) => {
-      const tab = document.createElement('div');
-      tab.className = 'tab';
-      tab.dataset.id = id;
-      tab.innerHTML = title + (id !== 'main' ? ' <span class="close">×</span>' : '');
-      document.getElementById('tabs').appendChild(tab);
-    });
-
-    ipcRenderer.on('close-tab', (event, id) => {
-      const tab = document.querySelector(`[data-id="${id}"]`);
-      if (tab) tab.remove();
-    });
-
-    ipcRenderer.on('update-active', (event, id) => {
-      const activeTab = document.querySelector('.tab.active');
-      if (activeTab) activeTab.classList.remove('active');
-      const newTab = document.querySelector(`[data-id="${id}"]`);
-      if (newTab) newTab.classList.add('active');
-      currentTab = id;
-    });
-
-    ipcRenderer.on('update-tab-title', (event, id, title) => {
-      const tab = document.querySelector(`[data-id="${id}"]`);
-      if (tab) {
-        tab.innerHTML = title + (id !== 'main' ? ' <span class="close">×</span>' : '');
-      }
-    });
-
-    let chatHeightValue = 300;
-    let isResizing = false;
-    let startY, startHeight;
-
-    ipcRenderer.on('chat-toggled', (event, visible, height) => {
-      chatHeightValue = height;
-      const resizer = document.getElementById('chat-resizer');
-      resizer.style.display = visible ? 'flex' : 'none';
-      resizer.style.bottom = visible ? height + 'px' : '-10px';
-    });
-
-    ipcRenderer.on('update-resizer', (event, height) => {
-      if (!isResizing) {
-        const resizer = document.getElementById('chat-resizer');
-        if (resizer.style.display !== 'none') {
-          resizer.style.bottom = height + 'px';
-        }
-      }
-    });
-
-    document.getElementById('chat-resizer').addEventListener('mousedown', (e) => {
-      isResizing = true;
-      startY = e.clientY;
-      startHeight = chatHeightValue;
-      document.getElementById('chat-resizer').classList.add('dragging');
-      e.preventDefault();
-    });
-
-    document.addEventListener('mousemove', (e) => {
-      if (isResizing) {
-        const delta = startY - e.clientY;
-        const newHeight = Math.max(200, Math.min(800, startHeight + delta));
-        chatHeightValue = newHeight;
-        const resizer = document.getElementById('chat-resizer');
-        resizer.style.bottom = newHeight + 'px';
-        ipcRenderer.send('update-chat-height', newHeight);
-      }
-    });
-
-    document.addEventListener('mouseup', (e) => {
-      if (isResizing) {
-        const resizer = document.getElementById('chat-resizer');
-        resizer.classList.remove('dragging');
-        const bottom = parseInt(resizer.style.bottom);
-        ipcRenderer.send('set-chat-height', bottom);
-        isResizing = false;
-      }
-    });
-
-    // Store current alert sound so we can stop it on click
-    let currentAlertAudio = null;
-
-    // Listen for alert sound request from main process (background timer)
-    // This runs in main window which is always loaded
-    ipcRenderer.on('play-alert-sound', (event, data) => {
-      console.log('Main window received play-alert-sound request:', data);
+</head>
+<body>
+  <div id="tabs-bar" style="width: 100%; height: fit-content; display: flex; align-items: stretch;">
+    <div id="tabs" style="overflow-x: auto; white-space: nowrap; flex: 1 1 auto; display: flex; align-items: stretch;">
+      <button id="nav-panel-toggle" style="display: flex; align-items: center; justify-content: center; font-size: 22px; border: none; background: #8b6914; color: #fff; border-radius: 8px 0 0 8px; width: 36px; height: 20px; cursor: pointer; margin-right: 4px; transition: background 0.2s;">&gt;</button>
+      <button id="nav-panel-strip-toggle" title="Toggle strip mode" style="display: flex; align-items: center; justify-content: center; font-size: 16px; border: none; background: #3d2807; color: #fff; border-radius: 6px; width: 36px; height: 20px; cursor: pointer; margin-right: 8px; transition: background 0.15s;">≡</button>
+      <div class="tab active" data-id="main">W2 HD</div>
       
-      if (data.customSoundPath) {
-        try {
-          // Stop any currently playing alert sound
-          if (currentAlertAudio) {
-            currentAlertAudio.pause();
-            currentAlertAudio.currentTime = 0;
-            currentAlertAudio.src = '';
+      <div class="nav">
+        <div class="nav-buttons-top">
+          <div class="nav-button" onclick="captureScreenshot()" title="Capture Screenshot">
+            <img src="assets/capture.png" class="nav-icon">
+          </div>
+          <div class="nav-button" onclick="openScreenshotFolder()" title="Open Screenshot Folder">
+            <img src="assets/folder.png" class="nav-icon">
+          </div>
+          <div class="nav-button" onclick="openSettingsPopup()" title="Settings" id="settings-nav-btn" style="position:relative;">
+            <img src="assets/settings.png" class="nav-icon">
+            <span id="update-badge" style="display:none;position:absolute;top:2px;right:2px;width:10px;height:10px;background:#51cf66;border-radius:50%;border:2px solid #141414;box-shadow:0 0 6px #51cf66;"></span>
+          </div>
+          <div class="nav-button" onclick="ipcRenderer.send('open-calculator')" title="Calculator">
+            <img src="assets/calculator.png" class="nav-icon" style="object-fit:cover;">
+          </div>
+        </div>
+      </div>
+    </div>
+    <div id="chat-resizer">
+      <div id="chat-resizer-line"></div>
+    </div>
+    <style>
+      #chat-resizer {
+        position: fixed;
+        left: 0;
+        right: 190px; /* matches NAV_PANEL_WIDTH */
+        height: 5px;
+        cursor: ns-resize;
+        z-index: 11;
+        display: none;
+        align-items: center;
+        transition: bottom 0.01s linear; /* JS drives this, keep near-instant */
+      }
+      #chat-resizer-line {
+        width: 100%;
+        height: 2px;
+        background: linear-gradient(90deg, transparent 0%, #5a4510 10%, #8b6914 40%, #c8941c 50%, #8b6914 60%, #5a4510 90%, transparent 100%);
+        pointer-events: none;
+        transition: opacity 0.15s;
+        opacity: 0.7;
+      }
+      #chat-resizer:hover #chat-resizer-line,
+      #chat-resizer.dragging #chat-resizer-line {
+        opacity: 1;
+        background: linear-gradient(90deg, transparent 0%, #8b6914 10%, #f0e68c 40%, #c8941c 50%, #f0e68c 60%, #8b6914 90%, transparent 100%);
+      }
+    </style>
+    <script>
+      const { ipcRenderer } = require('electron');
+      
+      let currentTab = 'main';
+      let navPanelCollapsed = false;
+      
+      const navPanelToggleBtn = document.getElementById('nav-panel-toggle');
+      function setNavPanelToggleState(collapsed) {
+        navPanelToggleBtn.textContent = collapsed ? '<' : '>';
+        navPanelToggleBtn.style.alignItems = 'center';
+        navPanelToggleBtn.style.justifyContent = 'center';
+        navPanelToggleBtn.style.background = collapsed ? 'transparent' : '#8b6914';
+        navPanelToggleBtn.style.color = collapsed ? '#8b6914' : '#fff';
+        navPanelToggleBtn.style.border = collapsed ? '2px solid #8b6914' : 'none';
+        
+        // Actually hide/show the nav panel
+        const navPanel = document.getElementById('nav-panel');
+        if (navPanel) {
+          if (collapsed) {
+            navPanel.style.display = 'none';
+          } else {
+            navPanel.style.display = '';
+          }
+        }
+      }
+      navPanelToggleBtn.onclick = () => {
+        navPanelCollapsed = !navPanelCollapsed;
+        setNavPanelToggleState(navPanelCollapsed);
+        require('electron').ipcRenderer.send('toggle-nav-panel');
+      };
+      const navPanelStripToggleBtn = document.getElementById('nav-panel-strip-toggle');
+      if (navPanelStripToggleBtn) {
+        navPanelStripToggleBtn.addEventListener('click', () => {
+          require('electron').ipcRenderer.send('toggle-nav-panel-mode');
+        });
+      }
+      require('electron').ipcRenderer.on('nav-panel-collapsed', (event, collapsed) => {
+        navPanelCollapsed = collapsed;
+        setNavPanelToggleState(collapsed);
+      });
+      require('electron').ipcRenderer.on('nav-panel-mode', (event, mode) => {
+        const btn = document.getElementById('nav-panel-strip-toggle');
+        if (!btn) return;
+        if (mode === 'strip') {
+          btn.style.background = '#51cf66';
+          btn.title = 'Strip mode enabled';
+        } else {
+          btn.style.background = '#3d2807';
+          btn.title = 'Enable strip mode';
+        }
+      });
+      // Set initial state (in case of reload)
+      setNavPanelToggleState(navPanelCollapsed);
+      
+      document.getElementById('tabs').addEventListener('click', (e) => {
+        if (e.target.classList.contains('close')) {
+          e.stopPropagation();
+          const tab = e.target.parentElement;
+          ipcRenderer.send('close-tab', tab.dataset.id);
+        } else if (e.target.classList.contains('tab')) {
+          ipcRenderer.send('switch-tab', e.target.dataset.id);
+        }
+      });
+      
+      ipcRenderer.on('add-tab', (event, id, title) => {
+        const tab = document.createElement('div');
+        tab.className = 'tab';
+        tab.dataset.id = id;
+        tab.innerHTML = title + (id !== 'main' ? ' <span class="close">×</span>' : '');
+        document.getElementById('tabs').appendChild(tab);
+      });
+      
+      ipcRenderer.on('close-tab', (event, id) => {
+        const tab = document.querySelector(`[data-id="${id}"]`);
+        if (tab) tab.remove();
+      });
+      
+      ipcRenderer.on('update-active', (event, id) => {
+        const activeTab = document.querySelector('.tab.active');
+        if (activeTab) activeTab.classList.remove('active');
+        const newTab = document.querySelector(`[data-id="${id}"]`);
+        if (newTab) newTab.classList.add('active');
+        currentTab = id;
+      });
+      
+      ipcRenderer.on('update-tab-title', (event, id, title) => {
+        const tab = document.querySelector(`[data-id="${id}"]`);
+        if (tab) {
+          tab.innerHTML = title + (id !== 'main' ? ' <span class="close">×</span>' : '');
+        }
+      });
+      
+      let chatHeightValue = 300;
+      let isResizing = false;
+      let startY, startHeight;
+      
+      ipcRenderer.on('chat-toggled', (event, visible, height) => {
+        chatHeightValue = height;
+        const resizer = document.getElementById('chat-resizer');
+        resizer.style.display = visible ? 'flex' : 'none';
+        resizer.style.bottom = visible ? height + 'px' : '-10px';
+      });
+      
+      ipcRenderer.on('update-resizer', (event, height) => {
+        if (!isResizing) {
+          const resizer = document.getElementById('chat-resizer');
+          if (resizer.style.display !== 'none') {
+            resizer.style.bottom = height + 'px';
+          }
+        }
+      });
+      
+      document.getElementById('chat-resizer').addEventListener('mousedown', (e) => {
+        isResizing = true;
+        startY = e.clientY;
+        startHeight = chatHeightValue;
+        document.getElementById('chat-resizer').classList.add('dragging');
+        e.preventDefault();
+      });
+      
+      document.addEventListener('mousemove', (e) => {
+        if (isResizing) {
+          const delta = startY - e.clientY;
+          const newHeight = Math.max(200, Math.min(800, startHeight + delta));
+          chatHeightValue = newHeight;
+          const resizer = document.getElementById('chat-resizer');
+          resizer.style.bottom = newHeight + 'px';
+          ipcRenderer.send('update-chat-height', newHeight);
+        }
+      });
+      
+      document.addEventListener('mouseup', (e) => {
+        if (isResizing) {
+          const resizer = document.getElementById('chat-resizer');
+          resizer.classList.remove('dragging');
+          const bottom = parseInt(resizer.style.bottom);
+          ipcRenderer.send('set-chat-height', bottom);
+          isResizing = false;
+        }
+      });
+      
+      // Store current alert sound so we can stop it on click
+      let currentAlertAudio = null;
+      
+      // Listen for alert sound request from main process (background timer)
+      // This runs in main window which is always loaded
+      ipcRenderer.on('play-alert-sound', (event, data) => {
+        console.log('Main window received play-alert-sound request:', data);
+        
+        if (data.customSoundPath) {
+          try {
+            // Stop any currently playing alert sound
+            if (currentAlertAudio) {
+              currentAlertAudio.pause();
+              currentAlertAudio.currentTime = 0;
+              currentAlertAudio.src = '';
+              currentAlertAudio = null;
+            }
+            
+            const audio = new Audio('file://' + data.customSoundPath);
+            audio.volume = data.soundVolume / 100;
+            currentAlertAudio = audio;
+            audio.play().then(() => {
+              console.log('Background alert sound played from main window');
+              // Clean up audio reference when playback ends naturally
+              audio.addEventListener('ended', () => {
+                if (currentAlertAudio === audio) currentAlertAudio = null;
+              }, { once: true });
+            }).catch(e => {
+              console.log('Failed to play sound in main window:', e);
+              currentAlertAudio = null;
+            });
+          } catch (e) {
+            console.log('Error playing sound in main window:', e);
             currentAlertAudio = null;
           }
-          
-          const audio = new Audio('file://' + data.customSoundPath);
-          audio.volume = data.soundVolume / 100;
-          currentAlertAudio = audio;
-          audio.play().then(() => {
-            console.log('Background alert sound played from main window');
-            // Clean up audio reference when playback ends naturally
-            audio.addEventListener('ended', () => {
-              if (currentAlertAudio === audio) currentAlertAudio = null;
-            }, { once: true });
-          }).catch(e => {
-            console.log('Failed to play sound in main window:', e);
-            currentAlertAudio = null;
-          });
-        } catch (e) {
-          console.log('Error playing sound in main window:', e);
-          currentAlertAudio = null;
         }
-      }
-    });
-
-    // Stop alert sound when user clicks anywhere on the game window
-    document.addEventListener('click', (e) => {
-      if (currentAlertAudio) {
-        console.log('User clicked - stopping alert sound');
-        currentAlertAudio.pause();
-        currentAlertAudio.currentTime = 0;
-        currentAlertAudio.src = '';
-        currentAlertAudio = null;
-      }
-    }, true); // Use capture phase to catch all clicks
-
-    // Listen for stop-alert-sound IPC from main process (when timer resets)
-    ipcRenderer.on('stop-alert-sound', () => {
-      // Stop any currently playing alert sound
-      if (currentAlertAudio) {
-        try {
-          // Pause and immediately seek to start to allow quick restart if needed
+      });
+      
+      // Stop alert sound when user clicks anywhere on the game window
+      document.addEventListener('click', (e) => {
+        if (currentAlertAudio) {
+          console.log('User clicked - stopping alert sound');
           currentAlertAudio.pause();
           currentAlertAudio.currentTime = 0;
-          // Remove the audio element to ensure it stops completely
           currentAlertAudio.src = '';
-        } catch (e) {
-          console.log('Error stopping audio:', e);
+          currentAlertAudio = null;
         }
-        currentAlertAudio = null;
+      }, true); // Use capture phase to catch all clicks
+      
+      // Listen for stop-alert-sound IPC from main process (when timer resets)
+      ipcRenderer.on('stop-alert-sound', () => {
+        // Stop any currently playing alert sound
+        if (currentAlertAudio) {
+          try {
+            // Pause and immediately seek to start to allow quick restart if needed
+            currentAlertAudio.pause();
+            currentAlertAudio.currentTime = 0;
+            // Remove the audio element to ensure it stops completely
+            currentAlertAudio.src = '';
+          } catch (e) {
+            console.log('Error stopping audio:', e);
+          }
+          currentAlertAudio = null;
+        }
+      });
+      // Screenshot functions
+      function captureScreenshot() {
+        ipcRenderer.send('capture-screenshot');
       }
-    });
-  </script>
-</body>
-</html>
+      
+      function openScreenshotFolder() {
+        ipcRenderer.send('open-screenshot-folder');
+      }
+      
+      function openSettingsPopup() {
+        ipcRenderer.send('open-settings-popup');
+      }
+    </script>
+  </body>
+  </html>
+  

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,7 @@
       border: 0px;
       padding: 0px;
       overflow-y: clip;
+      margin-left: 10px;
     }
 
     .nav-buttons-top {

--- a/src/main.css
+++ b/src/main.css
@@ -53,7 +53,7 @@ body {
     display: flex;
     align-items: center;
     margin-bottom: 2px;
-    padding: 8px 12px;
+    padding: 0px 0px;
     cursor: pointer;
     background: url('assets/button.jpg') repeat;
     background-size: cover;
@@ -82,7 +82,6 @@ body {
 .nav-icon {
     width: 24px;
     height: 24px;
-    margin-right: 12px;
     flex-shrink: 0;
 }
 
@@ -100,9 +99,9 @@ body {
 
 .strip-mode .nav-button {
     justify-content: flex-start;
-    padding-left: 12px;
-    padding-right: 46px;
-    min-height: 42px;
+    padding-left: 0px;
+    padding-right: 0px;
+    min-height: 32px;
 }
 
 .strip-mode .nav-button .nav-icon {
@@ -132,7 +131,6 @@ body {
 
 .strip-mode .nav-buttons-top .nav-icon {
     width: 20px;
-    height: 20px;
 }
 
 .strip-mode #nav-panel-strip-toggle {
@@ -203,14 +201,14 @@ body {
 .nav-buttons-top .nav-button {
     flex: 1;
     justify-content: center;
-    padding: 6px 8px;
-    min-height: 28px;
+    padding: 0px 0px;
+    min-height: 24px;
 }
 
 .nav-buttons-top .nav-icon {
     width: 18px;
     height: 18px;
-    margin-right: 0;
+    align-self: center;
 }
 
 .nav-buttons-top .nav-button {
@@ -312,7 +310,7 @@ button:active, .btn:active {
 }
 
 #tabs {
-    height: 28px;
+    height: 24px;
     background: linear-gradient(to bottom, #2a2a2a, #1a1a1a);
     display: flex;
     align-items: center;
@@ -322,7 +320,7 @@ button:active, .btn:active {
     left: 0;
     right: 0;
     z-index: 10;
-    padding: 0 6px;
+    padding: 0 0px;
     gap: 3px;
     overflow-x: auto;
     overflow-y: hidden;
@@ -733,8 +731,8 @@ button:active, .btn:active {
 }
 
 .open-external .icon {
-    width: 1.1em;
-    height: 1.1em;
+    width: 0.5em;
+    height: 0.5em;
     object-fit: contain;
     display: block;
 }
@@ -814,7 +812,6 @@ button:active, .btn:active {
 
 .nav-button .nav-icon {
     flex: 0 0 auto;
-    margin-right: 8px;
 }
 
 .nav-button.link {
@@ -868,10 +865,11 @@ button:active, .btn:active {
     align-items: center !important;
     justify-content: center !important;
     box-sizing: border-box !important;
-    width: 26px !important;
-    height: 26px !important;
-    padding: 3px !important;
-    border: 2px solid currentColor !important;
+    width: 16px !important;
+    height: 16px !important;
+    padding: 1px !important;
+    margin-left: 5px !important;
+    border: 1px solid currentColor !important;
     border-radius: 4px !important;
     background: transparent !important;
     transition: padding 0.15s ease, background 0.15s ease !important;

--- a/src/main.css
+++ b/src/main.css
@@ -40,7 +40,7 @@ body {
     background: #1a1a1a;
     border: 2px solid #8b6914;
     border-radius: 8px;
-    padding: 8px;
+    padding: 4px;
     overflow-y: auto;
     box-sizing: border-box;
 }
@@ -109,7 +109,7 @@ body {
 }
 
 .strip-mode .nav-button.link {
-    padding-right: 48px;
+    padding-right: 4px;
 }
 
 .strip-mode .nav-button .open-external {
@@ -815,7 +815,7 @@ button:active, .btn:active {
 }
 
 .nav-button.link {
-    padding-right: 40px;
+    padding-right: 4px;
 }
 
 .nav-button.link span:first-of-type {
@@ -824,7 +824,7 @@ button:active, .btn:active {
 
 .nav-button.link .open-external {
     position: absolute;
-    right: 10px;
+    right: 4px;
     top: 50%;
     transform: translateY(-50%);
     width: 20px;

--- a/src/main.js
+++ b/src/main.js
@@ -36,8 +36,8 @@ function snapToZoomStep(factor) {
   return closest;
 }
 
-const NAV_PANEL_WIDTH = 250;
-const NAV_PANEL_STRIP_WIDTH = 110;
+const NAV_PANEL_WIDTH = 190;
+const NAV_PANEL_STRIP_WIDTH = 70;
 let navPanelMode = 'expanded';
 let navPanelDesiredMode = 'expanded';
 let navPanelPrevMode = null;

--- a/src/main.js
+++ b/src/main.js
@@ -37,7 +37,7 @@ function snapToZoomStep(factor) {
 }
 
 const NAV_PANEL_WIDTH = 190;
-const NAV_PANEL_STRIP_WIDTH = 70;
+const NAV_PANEL_STRIP_WIDTH = 55;
 let navPanelMode = 'expanded';
 let navPanelDesiredMode = 'expanded';
 let navPanelPrevMode = null;

--- a/src/nav.html
+++ b/src/nav.html
@@ -11,23 +11,6 @@
 </head>
 <body>
     <div class="nav" id="nav-panel">
-        <!--
-        <div class="nav-buttons-top">
-            <div class="nav-button screenshot-btn" onclick="captureScreenshot()" title="Capture Screenshot">
-                <img src="assets/capture.png" class="nav-icon">
-            </div>
-            <div class="nav-button screenshot-btn" onclick="openScreenshotFolder()" title="Open Screenshot Folder">
-                <img src="assets/folder.png" class="nav-icon">
-            </div>
-            <div class="nav-button screenshot-btn" onclick="openSettingsPopup()" title="Settings" id="settings-nav-btn" style="position:relative;">
-                <img src="assets/settings.png" class="nav-icon">
-                <span id="update-badge" style="display:none;position:absolute;top:2px;right:2px;width:10px;height:10px;background:#51cf66;border-radius:50%;border:2px solid #141414;box-shadow:0 0 6px #51cf66;"></span>
-            </div>
-            <div class="nav-button screenshot-btn" onclick="ipcRenderer.send('open-calculator')" title="Calculator">
-                <img src="assets/calculator.png" class="nav-icon" style="width:30px; height:30px;">
-            </div>
-        </div>
-        -->
         <!-- strip toggle moved to header -->
         <div class="nav-button special-link" onclick="openNav('worldswitcher')" data-nav-id="worldswitcher">
             <img src="assets/LostCity.png" class="nav-icon">
@@ -110,21 +93,6 @@
         function toggleChat() { ipcRenderer.send('toggle-chat'); }
         function openExternal(url, title) { ipcRenderer.send('open-external', url, title); }
         function openNotes() { ipcRenderer.invoke('open-notes'); }
-        
-        /*
-        // Screenshot functions
-        function captureScreenshot() {
-        ipcRenderer.send('capture-screenshot');
-        }
-        
-        function openScreenshotFolder() {
-        ipcRenderer.send('open-screenshot-folder');
-        }
-        
-        function openSettingsPopup() {
-        ipcRenderer.send('open-settings-popup');
-        }
-        */
         
         function toggleNavPanel() {
             ipcRenderer.send('toggle-nav-panel');

--- a/src/nav.html
+++ b/src/nav.html
@@ -11,6 +11,7 @@
 </head>
 <body>
     <div class="nav" id="nav-panel">
+        <!--
         <div class="nav-buttons-top">
             <div class="nav-button screenshot-btn" onclick="captureScreenshot()" title="Capture Screenshot">
                 <img src="assets/capture.png" class="nav-icon">
@@ -26,6 +27,7 @@
                 <img src="assets/calculator.png" class="nav-icon" style="width:30px; height:30px;">
             </div>
         </div>
+        -->
         <!-- strip toggle moved to header -->
         <div class="nav-button special-link" onclick="openNav('worldswitcher')" data-nav-id="worldswitcher">
             <img src="assets/LostCity.png" class="nav-icon">
@@ -108,28 +110,30 @@
         function toggleChat() { ipcRenderer.send('toggle-chat'); }
         function openExternal(url, title) { ipcRenderer.send('open-external', url, title); }
         function openNotes() { ipcRenderer.invoke('open-notes'); }
-
+        
+        /*
         // Screenshot functions
         function captureScreenshot() {
-            ipcRenderer.send('capture-screenshot');
+        ipcRenderer.send('capture-screenshot');
         }
-
+        
         function openScreenshotFolder() {
-            ipcRenderer.send('open-screenshot-folder');
+        ipcRenderer.send('open-screenshot-folder');
         }
-
+        
         function openSettingsPopup() {
-            ipcRenderer.send('open-settings-popup');
+        ipcRenderer.send('open-settings-popup');
         }
-
+        */
+        
         function toggleNavPanel() {
             ipcRenderer.send('toggle-nav-panel');
         }
-
+        
         function toggleNavPanelStripMode() {
             ipcRenderer.send('toggle-nav-panel-mode');
         }
-
+        
         function setNavPanelMode(mode) {
             const stripBtn = document.getElementById('nav-panel-strip-toggle');
             const stripLabel = document.getElementById('nav-panel-strip-label');
@@ -143,23 +147,23 @@
             }
             document.body.classList.toggle('strip-mode', mode === 'strip');
         }
-
+        
         document.getElementById('nav-panel-strip-toggle')?.addEventListener('click', toggleNavPanelStripMode);
         ipcRenderer.on('nav-panel-mode', (event, mode) => {
             setNavPanelMode(mode || 'expanded');
         });
-
+        
         ipcRenderer.on('nav-panel-collapsed', (event, collapsed) => {
             const icon = document.getElementById('nav-toggle-icon');
             if (icon) icon.textContent = collapsed ? '⮜' : '⮞';
         });
-
+        
         function applyNavVisibility(hiddenIds) {
             document.querySelectorAll('[data-nav-id]').forEach(el => {
                 el.style.display = hiddenIds.includes(el.getAttribute('data-nav-id')) ? 'none' : '';
             });
         }
-
+        
         function updateChatButtonState(visible) {
             const chatButton = document.querySelector('.nav-button[data-nav-id="chat"]');
             if (!chatButton) return;
@@ -168,25 +172,25 @@
             const stateSpan = chatButton.querySelector('.chat-state');
             if (stateSpan) stateSpan.textContent = visible ? 'Disable chat' : 'Enable chat';
         }
-
+        
         ipcRenderer.on('chat-toggled', (event, visible) => {
             updateChatButtonState(visible);
         });
-
+        
         // Apply visibility on load
         ipcRenderer.invoke('get-hidden-nav-buttons').then(hiddenIds => {
             if (hiddenIds && hiddenIds.length) applyNavVisibility(hiddenIds);
         }).catch(() => {});
-
+        
         // React to live updates from settings
         ipcRenderer.on('update-nav-visibility', (event, hiddenIds) => {
             applyNavVisibility(hiddenIds);
         });
-
+        
         // ── Update badge ──────────────────────────────────────────────────────
         const updateBadge = document.getElementById('update-badge');
         const settingsBtn = document.getElementById('settings-nav-btn');
-
+        
         ipcRenderer.on('update-downloading', (event, version) => {
             if (updateBadge) {
                 updateBadge.style.display = 'block';
@@ -196,11 +200,11 @@
             }
             if (settingsBtn) settingsBtn.title = 'Settings (downloading update…)';
         });
-
+        
         ipcRenderer.on('update-progress', (event, pct) => {
             if (settingsBtn) settingsBtn.title = `Settings (update ${pct}%)`;
         });
-
+        
         ipcRenderer.on('update-ready', (event, version) => {
             if (updateBadge) {
                 updateBadge.style.display = 'block';


### PR DESCRIPTION
Mostly CSS changes to make the UI around the game view pane have less empty space.

Also moved the Screenshot, Settings, and Calculator buttons to the tab bar, this way they can be used while the sidebar is collapsed, while also not causing a change in layout height when the sidebar strip mode is enabled.

- Moved the `nav-buttons-top` and `Screenshot functions` blocks from `nav.html` to `index.html`, with extra inlined CSS to fit in the new layout.
- Changed padding, width, height, and margin values to make buttons look more compact.
- Changed `NAV_PANEL_WIDTH` and `NAV_PANEL_STRIP_WIDTH` values for a tighter fit.